### PR TITLE
Update to Dreamhost & one-click install instructions

### DIFF
--- a/docs/GettingStarted/Hosting_Suggestions.md
+++ b/docs/GettingStarted/Hosting_Suggestions.md
@@ -8,6 +8,7 @@ Hosting companies that use [Installatron](https://installatron.com/) should offe
 
 Suggestions from our users include:
 
+-   [Reclaim Hosting](https://reclaimhosting.com/) - offers one-click Omeka and Omeka S installations, with support for other open-source software platforms
 -   [Dotblock](http://www.dotblock.com) - uses Softaculous
 -   [HostGator](http://hostgator.com) - uses Softaculous
 -   [TMD Hosting](https://www.tmdhosting.com) - uses Softaculous
@@ -15,7 +16,6 @@ Suggestions from our users include:
 
 Below are a few suggestions for low-cost shared web hosts that offer the server environment required for installing Omeka manually:
 
--   [Reclaim Hosting](https://reclaimhosting.com/) - offers one-click Omeka and Omeka S installations, with support for other open-source software platforms
 -   [AcuGIS](http://www.acugis.com)
 -   [Cultural Hosting](https://culturalhosting.com) - a bilingual (Spanish and English) hosting company for cultural heritage organizations, based in Spain
 -   [Dreamhost](https://dreamhost.com)
@@ -25,4 +25,4 @@ Users have reported difficulty with the following shared web hosts:
 -   [1and1](http://www.1and1.com)
 -   [Siteground](http://www.siteground.com)
 
-You may also wish to try Softaculous AMPPS <http://www.ampps.com>, which creates a virtual website environment on your local computer, complete with databases, so that you can build your website offline or share it within an organization.
+You may also wish to try [Softaculous AMPPS](http://www.ampps.com), which creates a virtual website environment on your local computer, complete with databases, so that you can build your website offline or share it within an organization.

--- a/docs/GettingStarted/Hosting_Suggestions.md
+++ b/docs/GettingStarted/Hosting_Suggestions.md
@@ -12,20 +12,17 @@ Below are also a few suggestions for low-cost shared web hosts that offer the se
 
 Others follow in alphabetical order:
 
--   Academic AMIs on Amazon: <http://academicami.org/>
--   AcuGIS: <http://www.acugis.com/>
--   Cultural Hosting: <https://culturalhosting.com> a bilingual (Spanish and English) hosting company for cultural heritage organizations, based in Spain.
--   Dotblock: <http://www.dotblock.com/>
--   HostGator: <http://hostgator.com> 
--   Jumpbox: <http://www.jumpbox.com/app/omeka> 
+-   AcuGIS: <http://www.acugis.com>
+-   Cultural Hosting: <https://culturalhosting.com> - a bilingual (Spanish and English) hosting company for cultural heritage organizations, based in Spain.
+-   Dotblock: <http://www.dotblock.com> - uses Softaculous
+-   HostGator: <http://hostgator.com> - uses Softaculous
 -   Reclaim Hosting: <https://reclaimhosting.com> 
--   RexaHost: [http://hexahost.com](http://hexahost.com/omeka-web-hosting/) 
--   Softaculous AMPPS <http://www.ampps.com/>
--   TMD Hosting <https://www.tmdhosting.com>
--   Webfaction <http://webfaction.com/>
--   Webuzo <http://webuzo.com/apps/educational/Omeka> has a virtual appliance to run Omeka.
+-   TMD Hosting <https://www.tmdhosting.com> - uses Softaculous
+-   Webuzo <http://webuzo.com> - uses Softaculous
 
 Users have reported difficulty with the following shared web hosts:
 
 -   1and1 <http://www.1and1.com>
--   Siteground <http://www.siteground.com/>
+-   Siteground <http://www.siteground.com>
+
+You may also wish to try Softaculous AMPPS <http://www.ampps.com>, which creates a virtual website environment on your local computer, complete with databases, so that you can build your website offline or share it within an organization.

--- a/docs/GettingStarted/Hosting_Suggestions.md
+++ b/docs/GettingStarted/Hosting_Suggestions.md
@@ -4,11 +4,11 @@ If you lack access to a server that meets Omeka's [basic requirements](../Instal
 
 The Omeka Team offers fully managed, [isolated hosting](http://omeka.org/about/services/), which includes installation and updating of the core software and any themes or plugins developed by the Omeka Team, and direct technical support.
 
-Hosting companies which use [Installatron](https://installatron.com/) should offer a one-click install of Omeka Classic.
+Hosting companies that use [Installatron](https://installatron.com/) should offer a one-click install of [Omeka Classic](https://installatron.com/omeka). Hosting companies that use [Softaculous](https://softaculous.com/) should offer a one-click install of [Omeka Classic](https://www.softaculous.com/softaculous/apps/educational/Omeka) and [Omeka S](https://www.softaculous.com/softaculous/apps/others/Omeka_S).
 
 Below are also a few suggestions for low-cost shared web hosts that offer the server environment required for Omeka.
 
--   Reclaim Hosting: <https://reclaimhosting.com/> offers one-click Omeka and Omeka S installations, with support for other open-source software platforms.
+-   Reclaim Hosting: <https://reclaimhosting.com/> - offers one-click Omeka and Omeka S installations, with support for other open-source software platforms.
 
 Others follow in alphabetical order:
 
@@ -16,7 +16,6 @@ Others follow in alphabetical order:
 -   AcuGIS: <http://www.acugis.com/>
 -   Cultural Hosting: <https://culturalhosting.com> a bilingual (Spanish and English) hosting company for cultural heritage organizations, based in Spain.
 -   Dotblock: <http://www.dotblock.com/>
--   DreamHost: <http://dreamhost.com/> 
 -   HostGator: <http://hostgator.com> 
 -   Jumpbox: <http://www.jumpbox.com/app/omeka> 
 -   Reclaim Hosting: <https://reclaimhosting.com> 
@@ -27,5 +26,6 @@ Others follow in alphabetical order:
 -   Webuzo <http://webuzo.com/apps/educational/Omeka> has a virtual appliance to run Omeka.
 
 Users have reported difficulty with the following shared web hosts:
--   1and1 [http://1and1.com](http://www.1and1.com)
+
+-   1and1 <http://www.1and1.com>
 -   Siteground <http://www.siteground.com/>

--- a/docs/GettingStarted/Hosting_Suggestions.md
+++ b/docs/GettingStarted/Hosting_Suggestions.md
@@ -6,23 +6,23 @@ The Omeka Team offers fully managed, [isolated hosting](http://omeka.org/about/s
 
 Hosting companies that use [Installatron](https://installatron.com/) should offer a one-click install of [Omeka Classic](https://installatron.com/omeka). Hosting companies that use [Softaculous](https://softaculous.com/) should offer a one-click install of [Omeka Classic](https://www.softaculous.com/softaculous/apps/educational/Omeka) and [Omeka S](https://www.softaculous.com/softaculous/apps/others/Omeka_S).
 
-Below are also a few suggestions for low-cost shared web hosts that offer the server environment required for Omeka.
+Suggestions from our users include:
 
--   Reclaim Hosting: <https://reclaimhosting.com/> - offers one-click Omeka and Omeka S installations, with support for other open-source software platforms.
+-   [Dotblock](http://www.dotblock.com) - uses Softaculous
+-   [HostGator](http://hostgator.com) - uses Softaculous
+-   [TMD Hosting](https://www.tmdhosting.com) - uses Softaculous
+-   [Webuzo](http://webuzo.com) - uses Softaculous
 
-Others follow in alphabetical order:
+Below are a few suggestions for low-cost shared web hosts that offer the server environment required for installing Omeka manually:
 
--   AcuGIS: <http://www.acugis.com>
--   Cultural Hosting: <https://culturalhosting.com> - a bilingual (Spanish and English) hosting company for cultural heritage organizations, based in Spain.
--   Dotblock: <http://www.dotblock.com> - uses Softaculous
--   HostGator: <http://hostgator.com> - uses Softaculous
--   Reclaim Hosting: <https://reclaimhosting.com> 
--   TMD Hosting <https://www.tmdhosting.com> - uses Softaculous
--   Webuzo <http://webuzo.com> - uses Softaculous
+-   [Reclaim Hosting](https://reclaimhosting.com/) - offers one-click Omeka and Omeka S installations, with support for other open-source software platforms
+-   [AcuGIS](http://www.acugis.com)
+-   [Cultural Hosting](https://culturalhosting.com) - a bilingual (Spanish and English) hosting company for cultural heritage organizations, based in Spain
+-   [Dreamhost](https://dreamhost.com)
 
 Users have reported difficulty with the following shared web hosts:
 
--   1and1 <http://www.1and1.com>
--   Siteground <http://www.siteground.com>
+-   [1and1](http://www.1and1.com)
+-   [Siteground](http://www.siteground.com)
 
 You may also wish to try Softaculous AMPPS <http://www.ampps.com>, which creates a virtual website environment on your local computer, complete with databases, so that you can build your website offline or share it within an organization.

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -14,7 +14,7 @@ If you need to upgrade your server to meet any of the Omeka system requirements,
 
 7 Easy Steps for Installing with LAMP server setup 
 -----------
-Note: If you are doing a One-Click install from Dreamhost, you must edit the `db.ini` file in the Omeka directory (see 3 below).
+Note: If you are performing a [one-click install through a software management service](../GettingStarted/Hosting_Suggestions.md), you may need to edit the `db.ini` file in the Omeka directory (see 3 below).
 
 If you want to use Omeka Classic in a language other than English, you will need to configure it in the `/application/config/config.ini` file. See [Configuring Language](Configuring_Language.md) for details. The installation steps are localized, so you might want to do this before the rest of the installation steps below. It is fine to change this after your site is successfully installed.
 


### PR DESCRIPTION
Funnily enough, I was using Dreamhost to do some fresh Omeka installs earlier today and realized the one-click option no longer exists. (https://discussion.dreamhost.com/t/are-the-one-click-installs-one-forever/77527)
I'm removing the specific Dreamhost references and updating some of the mentions of one-click to specify Installatron and Softaculous. We should discuss if anyone has anything more to add to this - how does the organization keep track of these third-party vendors?
The Omeka S documentation should also be updated to include one-click options.