### PR TITLE
Update Base64 decoding snippet for MediaWiki > 1.35

### DIFF
--- a/docs/Plugins/Scripto.md
+++ b/docs/Plugins/Scripto.md
@@ -105,13 +105,13 @@ Scripto Base64 encodes document and page numbers to prevent incompatible MediaWi
 $wgHooks['BeforePageDisplay'][] = 'fnScriptoDecodePageTitle';
 function fnScriptoDecodePageTitle(&$out, &$sk, $prefix = '.', $delimiter = '.')
 {
-    $title = strtr($out->getPageTitle(), '-_', '+/');
+    $title = strip_tags(strtr($out->getPageTitle(), '-_', '+/'));
     if ($prefix != $title[0]) {
-        return false;
+        return;
     }
     $title = array_map('base64_decode', explode($delimiter, ltrim($title, $prefix)));
     $title = 'Document ' . $title[0] . '; Page ' . $title[1];
     $out->setPageTitle($title);
-    return false;
+    return;
 }
 ```


### PR DESCRIPTION
The code snippet suggested for Base64 decoding page titles throws errors on more recent versions of MediaWiki, e.g. 

```
UnexpectedValueException: Handler fnScriptoDecodePageTitle return false for unabortable BeforePageDisplay.
```

This seems to be due to changes in [hook handler return values](https://www.mediawiki.org/wiki/Manual:Hooks#Hook_handler_return_values) no longer accepting `false` as valid for unabortable hooks like BeforeDisplayTitle. Returning void works as intended.

The prefix checking logic was also not working correctly, since $title[0] in line 109 was returning the "<" of HTML markup instead of the "." intended. Wrapping the strtr() function in strip_tags() seems to fix it. 